### PR TITLE
Regular expressions admit characters from the Spanish language

### DIFF
--- a/src/main/java/com/alkemy/ong/application/util/RegExpressionUtils.java
+++ b/src/main/java/com/alkemy/ong/application/util/RegExpressionUtils.java
@@ -2,9 +2,9 @@ package com.alkemy.ong.application.util;
 
 public class RegExpressionUtils {
 
-  public static final String ALPHABETIC_CHARACTERS_WITH_BLANK_SPACES = "^[a-zA-Z_ ]*$";
-  public static final String ALPHANUMERIC_CHARACTERS_WITHOUT_BLANK_SPACES = "^[a-zA-Z0-9_]*$";
-  public static final String ALPHANUMERIC_CHARACTERS_WITH_BLANK_SPACES = "^[a-zA-Z0-9_ ]*$";
+  public static final String ALPHABETIC_CHARACTERS_WITH_BLANK_SPACES = "^[a-zA-ZñÑáéíóúÁÉÍÓÚüÜ_ ]*$";
+  public static final String ALPHANUMERIC_CHARACTERS_WITHOUT_BLANK_SPACES = "^[a-zA-Z0-9ñÑáéíóúÁÉÍÓÚüÜ_]*$";
+  public static final String ALPHANUMERIC_CHARACTERS_WITH_BLANK_SPACES = "^[a-zA-Z0-9ñÑáéíóúÁÉÍÓÚüÜ_ ]*$";
 
   private RegExpressionUtils() {
 

--- a/src/main/java/com/alkemy/ong/application/util/RegExpressionUtils.java
+++ b/src/main/java/com/alkemy/ong/application/util/RegExpressionUtils.java
@@ -2,9 +2,12 @@ package com.alkemy.ong.application.util;
 
 public class RegExpressionUtils {
 
-  public static final String ALPHABETIC_CHARACTERS_WITH_BLANK_SPACES = "^[a-zA-ZñÑáéíóúÁÉÍÓÚüÜ_ ]*$";
-  public static final String ALPHANUMERIC_CHARACTERS_WITHOUT_BLANK_SPACES = "^[a-zA-Z0-9ñÑáéíóúÁÉÍÓÚüÜ_]*$";
-  public static final String ALPHANUMERIC_CHARACTERS_WITH_BLANK_SPACES = "^[a-zA-Z0-9ñÑáéíóúÁÉÍÓÚüÜ_ ]*$";
+  public static final String ALPHABETIC_CHARACTERS_WITH_BLANK_SPACES =
+      "^[a-zA-ZñÑáéíóúÁÉÍÓÚüÜ_ ]*$";
+  public static final String ALPHANUMERIC_CHARACTERS_WITHOUT_BLANK_SPACES =
+      "^[a-zA-Z0-9ñÑáéíóúÁÉÍÓÚüÜ_]*$";
+  public static final String ALPHANUMERIC_CHARACTERS_WITH_BLANK_SPACES =
+      "^[a-zA-Z0-9ñÑáéíóúÁÉÍÓÚüÜ_ ]*$";
 
   private RegExpressionUtils() {
 


### PR DESCRIPTION
# Regular expressions admit characters from the Spanish language

Las expresiones regulares en su estado original no admiten letras con acentos o diéresis ni eñes (Ñ). Con esta pequeña corrección ya admiten caracteres de la lengua española. 

### HOW HAS THIS BEEN TESTED?

- [x] Postman.
- [ ] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

### Screenshots:

**--> Este cambio es necesario para corregir este bug: <--** 

![error expresión regular2](https://user-images.githubusercontent.com/88750230/160307386-72ba9cd0-81f8-4a0a-a417-b3384752fcde.png)

### CHECKLIST

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
