### PR TITLE
OT166-84: Add documentation with Swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-ui</artifactId>
+      <version>1.6.6</version>
+    </dependency>
   </dependencies>
 
   <description>ONG project with Spring Boot</description>

--- a/src/main/java/com/alkemy/ong/infrastructure/spring/config/security/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/spring/config/security/SecurityConfig.java
@@ -70,6 +70,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
         .authorizeRequests()
+        .antMatchers("/api/docs/**")
+        .permitAll()
         .antMatchers(HttpMethod.GET, "/organization/public")
         .permitAll()
         .antMatchers(HttpMethod.POST, "/auth/login")

--- a/src/main/java/com/alkemy/ong/infrastructure/spring/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/spring/config/swagger/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package com.alkemy.ong.infrastructure.spring.config.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  private static final String TITLE = "Somos más";
+  private static final String DESCRIPTION = "We are a non-profit civil association that was "
+      + "created in 1997 with the intention of giving food to families in the neighborhood. "
+      + "Over time we got involved with the community and expanded and improved our work "
+      + "capacity. We are a community center that accompanies more than 700 people through "
+      + "the areas of: Education, sports, early childhood, health, food and social work.";
+
+  @Bean
+  public OpenAPI api() {
+    return new OpenAPI()
+        .info(new Info().title(TITLE)
+            .description(DESCRIPTION)
+        );
+  }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,6 @@ spring.jpa.hibernate.ddl-auto=update
 # SendGrid
 app.sendgrid.key=foo
 organization.from.email=somosmas@gamil.com
+# Swagger
+springdoc.api-docs.path=/api/docs
+springdoc.swagger-ui.path=/api/docs/swagger-ui

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,3 +9,6 @@ spring.sql.init.platform=h2
 # SendGrid
 app.sendgrid.key=foo
 organization.from.email=somosmas@gmail.com
+# Swagger
+springdoc.api-docs.path=/api/docs
+springdoc.swagger-ui.path=/api/docs/swagger-ui


### PR DESCRIPTION
# [OT166-84: Add documentation with Swagger](https://alkemy-labs.atlassian.net/browse/OT166-84)

### Criterios de aceptación
Se deberá implementar la librería Swagger para documentar los diferentes endpoints del proyecto. 
Al ingresar al endpoint /api/docs, se deberá mostrar el layout.

### HOW HAS THIS BEEN TESTED?

- [ ] Postman.
- [ ] Unit test.
- [ ] Integration test.
- [x] No testing required (only applies for tech task).

![swagger](https://user-images.githubusercontent.com/88750230/160895278-f0f978cf-9d09-4842-8aed-e4eaf8f5be30.png)

### CHECKLIST

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
