### PR TITLE
OT166-82: Agregar paginación a Miembros

### DIFF
--- a/etc/postman/OT166.postman_collection.json
+++ b/etc/postman/OT166.postman_collection.json
@@ -450,10 +450,26 @@
 				{
 					"name": "GET member ADMIN",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{token}}",
+									"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": ""
+							"raw": "{{URL}}/members",
+							"host": [
+								"{{URL}}"
+							],
+							"path": [
+								"members"
+							]
 						}
 					},
 					"response": []

--- a/src/main/java/com/alkemy/ong/application/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/application/rest/resource/MemberResource.java
@@ -8,9 +8,12 @@ import com.alkemy.ong.application.service.abstraction.ICreateMemberService;
 import com.alkemy.ong.application.service.abstraction.IDeleteMemberService;
 import com.alkemy.ong.application.service.abstraction.IGetMemberService;
 import com.alkemy.ong.application.service.abstraction.IUpdateMemberService;
+import com.alkemy.ong.application.util.PaginatedResultsRetrieved;
 import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequestMapping("members")
@@ -39,6 +43,9 @@ public class MemberResource {
   @Autowired
   private IUpdateMemberService updateMemberService;
 
+  @Autowired
+  private PaginatedResultsRetrieved paginatedResultsRetrieved;
+
   @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE,
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<MemberResponse> create(
@@ -48,8 +55,18 @@ public class MemberResource {
   }
 
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<ListMembersResponse> listActiveMembers() {
-    return ResponseEntity.ok().body(getMemberService.listActiveMembers());
+  public ResponseEntity<ListMembersResponse> listActiveMembers(Pageable pageable,
+      UriComponentsBuilder uriBuilder,
+      HttpServletResponse response) {
+    ListMembersResponse listMembersResponse = getMemberService.findAll(pageable);
+
+    paginatedResultsRetrieved.addLinkHeaderOnPagedResourceRetrieval(
+        uriBuilder, response,"/news",
+        listMembersResponse.getPage(),
+        listMembersResponse.getTotalPages(),
+        listMembersResponse.getSize());
+
+    return ResponseEntity.ok().body(listMembersResponse);
   }
 
   @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/alkemy/ong/application/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/application/rest/resource/MemberResource.java
@@ -58,7 +58,7 @@ public class MemberResource {
   public ResponseEntity<ListMembersResponse> listActiveMembers(Pageable pageable,
       UriComponentsBuilder uriBuilder,
       HttpServletResponse response) {
-    ListMembersResponse listMembersResponse = getMemberService.findAll(pageable);
+    ListMembersResponse listMembersResponse = getMemberService.listActiveMembers(pageable);
 
     paginatedResultsRetrieved.addLinkHeaderOnPagedResourceRetrieval(
         uriBuilder, response,"/members",

--- a/src/main/java/com/alkemy/ong/application/rest/resource/MemberResource.java
+++ b/src/main/java/com/alkemy/ong/application/rest/resource/MemberResource.java
@@ -61,7 +61,7 @@ public class MemberResource {
     ListMembersResponse listMembersResponse = getMemberService.findAll(pageable);
 
     paginatedResultsRetrieved.addLinkHeaderOnPagedResourceRetrieval(
-        uriBuilder, response,"/news",
+        uriBuilder, response,"/members",
         listMembersResponse.getPage(),
         listMembersResponse.getTotalPages(),
         listMembersResponse.getSize());

--- a/src/main/java/com/alkemy/ong/application/rest/response/ListMembersResponse.java
+++ b/src/main/java/com/alkemy/ong/application/rest/response/ListMembersResponse.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class ListMembersResponse {
+public class ListMembersResponse extends PaginationResponse  {
 
   List<MemberResponse> members;
 

--- a/src/main/java/com/alkemy/ong/application/service/MemberService.java
+++ b/src/main/java/com/alkemy/ong/application/service/MemberService.java
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -67,18 +67,18 @@ public class MemberService implements ICreateMemberService,
   @Override
   public ListMembersResponse findAll(Pageable pageable) {
     Page<MemberEntity> page =
-        memberRepository.findBySoftDeleteFalseOrderByTimestampDesc(pageable);
+        memberRepository.findBySoftDeletedFalseOrderByCreateTimestampDesc(pageable);
     ListMembersResponse listMembersResponse = new ListMembersResponse();
     listMembersResponse.setMembers(memberMapper.toListMemberResponse(page.getContent()));
     return buildListResponse(listMembersResponse,page);
   }
 
   private ListMembersResponse buildListResponse(
-      ListMembersResponse listMembersResponse, Page<MemberEntity> page) {
-    listMembersResponse.setPage(page.getNumber());
-    listMembersResponse.setTotalPages(page.getTotalPages());
-    listMembersResponse.setSize(page.getSize());
-    return listMembersResponse;
+      ListMembersResponse listM, Page<MemberEntity> page) {
+    listM.setPage(page.getNumber());
+    listM.setTotalPages(page.getTotalPages());
+    listM.setSize(page.getSize());
+    return listM;
   }
 
   @Override

--- a/src/main/java/com/alkemy/ong/application/service/MemberService.java
+++ b/src/main/java/com/alkemy/ong/application/service/MemberService.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -59,6 +61,23 @@ public class MemberService implements ICreateMemberService,
     List<MemberEntity> memberEntities = memberRepository.findBySoftDeletedIsFalse();
     ListMembersResponse listMembersResponse = new ListMembersResponse();
     listMembersResponse.setMembers(memberMapper.toListMemberResponse(memberEntities));
+    return listMembersResponse;
+  }
+
+  @Override
+  public ListMembersResponse findAll(Pageable pageable) {
+    Page<MemberEntity> page =
+        memberRepository.findBySoftDeleteFalseOrderByTimestampDesc(pageable);
+    ListMembersResponse listMembersResponse = new ListMembersResponse();
+    listMembersResponse.setMembers(memberMapper.toListMemberResponse(page.getContent()));
+    return buildListResponse(listMembersResponse,page);
+  }
+
+  private ListMembersResponse buildListResponse(
+      ListMembersResponse listMembersResponse, Page<MemberEntity> page) {
+    listMembersResponse.setPage(page.getNumber());
+    listMembersResponse.setTotalPages(page.getTotalPages());
+    listMembersResponse.setSize(page.getSize());
     return listMembersResponse;
   }
 

--- a/src/main/java/com/alkemy/ong/application/service/MemberService.java
+++ b/src/main/java/com/alkemy/ong/application/service/MemberService.java
@@ -57,28 +57,19 @@ public class MemberService implements ICreateMemberService,
   }
 
   @Override
-  public ListMembersResponse listActiveMembers() {
-    List<MemberEntity> memberEntities = memberRepository.findBySoftDeletedIsFalse();
-    ListMembersResponse listMembersResponse = new ListMembersResponse();
-    listMembersResponse.setMembers(memberMapper.toListMemberResponse(memberEntities));
-    return listMembersResponse;
-  }
-
-  @Override
-  public ListMembersResponse findAll(Pageable pageable) {
-    Page<MemberEntity> page =
-        memberRepository.findBySoftDeletedFalseOrderByCreateTimestampDesc(pageable);
+  public ListMembersResponse listActiveMembers(Pageable pageable) {
+    Page<MemberEntity> page = memberRepository.findBySoftDeletedIsFalse(pageable);
     ListMembersResponse listMembersResponse = new ListMembersResponse();
     listMembersResponse.setMembers(memberMapper.toListMemberResponse(page.getContent()));
     return buildListResponse(listMembersResponse,page);
   }
 
   private ListMembersResponse buildListResponse(
-      ListMembersResponse listM, Page<MemberEntity> page) {
-    listM.setPage(page.getNumber());
-    listM.setTotalPages(page.getTotalPages());
-    listM.setSize(page.getSize());
-    return listM;
+      ListMembersResponse listMembersResponse, Page<MemberEntity> page) {
+    listMembersResponse.setPage(page.getNumber());
+    listMembersResponse.setTotalPages(page.getTotalPages());
+    listMembersResponse.setSize(page.getSize());
+    return listMembersResponse;
   }
 
   @Override

--- a/src/main/java/com/alkemy/ong/application/service/abstraction/IGetMemberService.java
+++ b/src/main/java/com/alkemy/ong/application/service/abstraction/IGetMemberService.java
@@ -5,8 +5,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface IGetMemberService {
 
-  ListMembersResponse listActiveMembers();
-
-  ListMembersResponse findAll(Pageable pageable);
+  ListMembersResponse listActiveMembers(Pageable pageable);
 
 }

--- a/src/main/java/com/alkemy/ong/application/service/abstraction/IGetMemberService.java
+++ b/src/main/java/com/alkemy/ong/application/service/abstraction/IGetMemberService.java
@@ -1,9 +1,12 @@
 package com.alkemy.ong.application.service.abstraction;
 
 import com.alkemy.ong.application.rest.response.ListMembersResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface IGetMemberService {
 
   ListMembersResponse listActiveMembers();
+
+  ListMembersResponse findAll(Pageable pageable);
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/IMemberRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/IMemberRepository.java
@@ -1,9 +1,9 @@
 package com.alkemy.ong.infrastructure.database.repository;
 
 import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +12,6 @@ public interface IMemberRepository extends JpaRepository<MemberEntity, Long> {
 
   List<MemberEntity> findBySoftDeletedIsFalse();
 
-  Page<MemberEntity> findBySoftDeleteFalseOrderByTimestampDesc(Pageable pageable);
+  Page<MemberEntity> findBySoftDeletedFalseOrderByCreateTimestampDesc(Pageable pageable);
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/IMemberRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/IMemberRepository.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface IMemberRepository extends JpaRepository<MemberEntity, Long> {
 
-  List<MemberEntity> findBySoftDeletedIsFalse();
-
-  Page<MemberEntity> findBySoftDeletedFalseOrderByCreateTimestampDesc(Pageable pageable);
+  Page<MemberEntity> findBySoftDeletedIsFalse(Pageable pageable);
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/IMemberRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/IMemberRepository.java
@@ -1,6 +1,8 @@
 package com.alkemy.ong.infrastructure.database.repository;
 
 import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface IMemberRepository extends JpaRepository<MemberEntity, Long> {
 
   List<MemberEntity> findBySoftDeletedIsFalse();
+
+  Page<MemberEntity> findBySoftDeleteFalseOrderByTimestampDesc(Pageable pageable);
 
 }


### PR DESCRIPTION
# https://alkemy-labs.atlassian.net/browse/OT166-82 Agregar paginación a Miembros

Modificar el endpoint GET /members para que cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados en el body y en las headers de la respuesta las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page

### HOW HAS THIS BEEN TESTED?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration.

- [x] Postman.
- [ ] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

**Test Configuration**:

* ...
* ...

**Screenshots**:

![memberPage2](https://user-images.githubusercontent.com/66212987/162768658-8bf72c29-5bbe-42dc-aa10-b0b59f1e8ec8.png)
![memberPage3](https://user-images.githubusercontent.com/66212987/162768671-c7817391-159d-4ea2-88c8-f510a4d0e04c.png)
![memberPage](https://user-images.githubusercontent.com/66212987/162768674-896a1082-4859-4125-b43c-1f6cf609b6ad.png)

### CHECKLIST

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added the new resource in the Postman Collection file.
