### PR TITLE
OT166-91: Test endpoints /members

### DIFF
--- a/src/test/java/com/alkemy/ong/bigtest/members/CreateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/CreateMemberIntegrationTest.java
@@ -23,13 +23,13 @@ import org.springframework.http.MediaType;
 
 public class CreateMemberIntegrationTest extends BigTest {
 
-  private static final String correctName = "Magali Kain";
-  private static final String correctImage = "https://s3.com/maga.png";
+  private static final String CORRECT_NAME = "Magali Kain";
+  private static final String CORRECT_IMAGE = "https://s3.com/maga.png";
 
   @Test
   public void shouldCreateMemberWhenUserHasStandardUserRole() throws Exception {
     String response = mockMvc.perform(post("/members")
-            .content(getContent(correctName, correctImage))
+            .content(getContent(CORRECT_NAME, CORRECT_IMAGE))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.id", notNullValue()))
@@ -37,6 +37,7 @@ public class CreateMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.image", equalTo("https://s3.com/maga.png")))
         .andExpect(status().isCreated())
         .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
     Integer memberId = JsonPath.read(response, "$.id");
     assertMemberHasBeenCreated(Long.valueOf(memberId));
   }
@@ -65,7 +66,7 @@ public class CreateMemberIntegrationTest extends BigTest {
   @Test
   public void shouldReturnBadRequestWhenNameIsNull() throws Exception {
     mockMvc.perform(post("/members")
-            .content(getContent(null, correctImage))
+            .content(getContent(null, CORRECT_IMAGE))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -78,7 +79,7 @@ public class CreateMemberIntegrationTest extends BigTest {
   @Test
   public void shouldReturnBadRequestWhenInvalidName() throws Exception {
     mockMvc.perform(post("/members")
-            .content(getContent("M4gálï K@1ñ", correctImage))
+            .content(getContent("M4gálï K@1ñ", CORRECT_IMAGE))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -91,7 +92,7 @@ public class CreateMemberIntegrationTest extends BigTest {
   @Test
   public void shouldReturnBadRequestWhenImageIsNull() throws Exception {
     mockMvc.perform(post("/members")
-            .content(getContent(correctName, null))
+            .content(getContent(CORRECT_NAME, null))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -104,7 +105,7 @@ public class CreateMemberIntegrationTest extends BigTest {
   @Test
   public void shouldReturnBadRequestWhenInvalidImage() throws Exception {
     mockMvc.perform(post("/members")
-            .content(getContent(correctName, "Magali's-dog-photo.png"))
+            .content(getContent(CORRECT_NAME, "Magali's-dog-photo.png"))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -125,8 +126,8 @@ public class CreateMemberIntegrationTest extends BigTest {
     final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     assertTrue(optionalMemberEntity.isPresent());
     optionalMemberEntity.ifPresent(memberEntity -> {
-      assertEquals(correctName, memberEntity.getName());
-      assertEquals(correctImage, memberEntity.getImage());
+      assertEquals(CORRECT_NAME, memberEntity.getName());
+      assertEquals(CORRECT_IMAGE, memberEntity.getImage());
       cleanMemberData(memberEntity);
     });
   }

--- a/src/test/java/com/alkemy/ong/bigtest/members/CreateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/CreateMemberIntegrationTest.java
@@ -1,0 +1,136 @@
+package com.alkemy.ong.bigtest.members;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.alkemy.ong.application.rest.request.CreateMemberRequest;
+import com.alkemy.ong.bigtest.util.BigTest;
+import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jayway.jsonpath.JsonPath;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class CreateMemberIntegrationTest extends BigTest {
+
+  private static final String correctName = "Magali Kain";
+  private static final String correctImage = "https://s3.com/maga.png";
+
+  @Test
+  public void shouldCreateMemberWhenUserHasStandardUserRole() throws Exception {
+
+    String response = mockMvc.perform(post("/members")
+            .content(getContent(correctName, correctImage))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.id", notNullValue()))
+        .andExpect(jsonPath("$.name", equalTo("Magali Kain")))
+        .andExpect(jsonPath("$.image", equalTo("https://s3.com/maga.png")))
+        .andExpect(status().isCreated())
+        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+    Integer memberId = JsonPath.read(response, "$.id");
+    assertMemberHasBeenCreated(Long.valueOf(memberId));
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenUserHasAdminRole() throws Exception {
+    mockMvc.perform(post("/members")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenTokenIsNotSent() throws Exception {
+    mockMvc.perform(post("/members")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenNameIsNull() throws Exception {
+    mockMvc.perform(post("/members")
+            .content(getContent(null, correctImage))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The name must not be null")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenInvalidName() throws Exception {
+    mockMvc.perform(post("/members")
+            .content(getContent("M4gálï K@1ñ", correctImage))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The name has invalid format.")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenImageIsNull() throws Exception {
+    mockMvc.perform(post("/members")
+            .content(getContent(correctName, null))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The image must not be null")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenInvalidImage() throws Exception {
+    mockMvc.perform(post("/members")
+            .content(getContent(correctName, "Magali's-dog-photo.png"))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The image has invalid format.")))
+        .andExpect(status().isBadRequest());
+  }
+
+  private String getContent(String name, String image) throws JsonProcessingException {
+    return objectMapper.writeValueAsString(CreateMemberRequest.builder()
+        .name(name)
+        .image(image)
+        .build());
+  }
+
+  private void assertMemberHasBeenCreated(Long memberId) {
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    assertTrue(optionalMemberEntity.isPresent());
+    optionalMemberEntity.ifPresent(memberEntity -> {
+      assertEquals(correctName, memberEntity.getName());
+      assertEquals(correctImage, memberEntity.getImage());
+      cleanMemberData(memberEntity);
+    });
+  }
+
+}

--- a/src/test/java/com/alkemy/ong/bigtest/members/CreateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/CreateMemberIntegrationTest.java
@@ -28,7 +28,6 @@ public class CreateMemberIntegrationTest extends BigTest {
 
   @Test
   public void shouldCreateMemberWhenUserHasStandardUserRole() throws Exception {
-
     String response = mockMvc.perform(post("/members")
             .content(getContent(correctName, correctImage))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -38,7 +37,6 @@ public class CreateMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.image", equalTo("https://s3.com/maga.png")))
         .andExpect(status().isCreated())
         .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
     Integer memberId = JsonPath.read(response, "$.id");
     assertMemberHasBeenCreated(Long.valueOf(memberId));
   }
@@ -124,7 +122,7 @@ public class CreateMemberIntegrationTest extends BigTest {
   }
 
   private void assertMemberHasBeenCreated(Long memberId) {
-    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     assertTrue(optionalMemberEntity.isPresent());
     optionalMemberEntity.ifPresent(memberEntity -> {
       assertEquals(correctName, memberEntity.getName());

--- a/src/test/java/com/alkemy/ong/bigtest/members/DeleteMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/DeleteMemberIntegrationTest.java
@@ -1,0 +1,83 @@
+package com.alkemy.ong.bigtest.members;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.alkemy.ong.bigtest.util.BigTest;
+import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import java.util.Optional;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class DeleteMemberIntegrationTest extends BigTest {
+
+  @Test
+  public void shouldDeleteMemberWhenUserHasAdminRole() throws Exception {
+    MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
+        .andExpect(jsonPath("$").doesNotExist())
+        .andExpect(status().isNoContent());
+    assertMemberHasBeenDeleted(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenUserHasStandardUserRole() throws Exception {
+    MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+    assertMemberHasNotBeenDeleted(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenTokenIsNotSent() throws Exception {
+    MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+    assertMemberHasNotBeenDeleted(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnNotFoundErrorResponseWhenUserNotExist() throws Exception {
+    final String nonExistMemberId = "1000000";
+    mockMvc.perform(delete("/members/{id}", nonExistMemberId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(404)))
+        .andExpect(jsonPath("$.message", equalTo("Entity not found.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("Member not found.")))
+        .andExpect(status().isNotFound());
+  }
+
+  private void assertMemberHasBeenDeleted(Long memberId) {
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    optionalMemberEntity.ifPresent(memberEntity -> assertTrue(memberEntity.getSoftDeleted()));
+  }
+
+  private void assertMemberHasNotBeenDeleted(Long memberId) {
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    optionalMemberEntity.ifPresent(memberEntity -> assertFalse(memberEntity.getSoftDeleted()));
+  }
+
+}

--- a/src/test/java/com/alkemy/ong/bigtest/members/DeleteMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/DeleteMemberIntegrationTest.java
@@ -20,19 +20,22 @@ public class DeleteMemberIntegrationTest extends BigTest {
 
   @Test
   public void shouldDeleteMemberWhenUserHasAdminRole() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
         .andExpect(jsonPath("$").doesNotExist())
         .andExpect(status().isNoContent());
+
     assertMemberHasBeenDeleted(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnForbiddenErrorResponseWhenUserHasStandardUserRole() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
@@ -40,26 +43,30 @@ public class DeleteMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.message",
             equalTo("Access denied. Please, try to login again or contact your admin.")))
         .andExpect(status().isForbidden());
+
     assertMemberHasNotBeenDeleted(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnForbiddenErrorResponseWhenTokenIsNotSent() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.statusCode", equalTo(403)))
         .andExpect(jsonPath("$.message",
             equalTo("Access denied. Please, try to login again or contact your admin.")))
         .andExpect(status().isForbidden());
+
     assertMemberHasNotBeenDeleted(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnNotFoundErrorResponseWhenUserNotExist() throws Exception {
-    final String nonExistMemberId = "1000000";
+    String nonExistMemberId = "1000000";
+
     mockMvc.perform(delete("/members/{id}", nonExistMemberId)
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
@@ -71,12 +78,12 @@ public class DeleteMemberIntegrationTest extends BigTest {
   }
 
   private void assertMemberHasBeenDeleted(Long memberId) {
-    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     optionalMemberEntity.ifPresent(memberEntity -> assertTrue(memberEntity.getSoftDeleted()));
   }
 
   private void assertMemberHasNotBeenDeleted(Long memberId) {
-    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     optionalMemberEntity.ifPresent(memberEntity -> assertFalse(memberEntity.getSoftDeleted()));
   }
 

--- a/src/test/java/com/alkemy/ong/bigtest/members/DeleteMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/DeleteMemberIntegrationTest.java
@@ -20,7 +20,7 @@ public class DeleteMemberIntegrationTest extends BigTest {
 
   @Test
   public void shouldDeleteMemberWhenUserHasAdminRole() throws Exception {
-    MemberEntity randomMember = getRandomMember();
+    final MemberEntity randomMember = getRandomMember();
     mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
@@ -32,7 +32,7 @@ public class DeleteMemberIntegrationTest extends BigTest {
 
   @Test
   public void shouldReturnForbiddenErrorResponseWhenUserHasStandardUserRole() throws Exception {
-    MemberEntity randomMember = getRandomMember();
+    final MemberEntity randomMember = getRandomMember();
     mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
@@ -46,7 +46,7 @@ public class DeleteMemberIntegrationTest extends BigTest {
 
   @Test
   public void shouldReturnForbiddenErrorResponseWhenTokenIsNotSent() throws Exception {
-    MemberEntity randomMember = getRandomMember();
+    final MemberEntity randomMember = getRandomMember();
     mockMvc.perform(delete("/members/{id}", String.valueOf(randomMember.getId()))
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.statusCode", equalTo(403)))
@@ -71,12 +71,12 @@ public class DeleteMemberIntegrationTest extends BigTest {
   }
 
   private void assertMemberHasBeenDeleted(Long memberId) {
-    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     optionalMemberEntity.ifPresent(memberEntity -> assertTrue(memberEntity.getSoftDeleted()));
   }
 
   private void assertMemberHasNotBeenDeleted(Long memberId) {
-    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     optionalMemberEntity.ifPresent(memberEntity -> assertFalse(memberEntity.getSoftDeleted()));
   }
 

--- a/src/test/java/com/alkemy/ong/bigtest/members/ListMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/ListMemberIntegrationTest.java
@@ -16,7 +16,7 @@ public class ListMemberIntegrationTest extends BigTest {
 
   @Test
   public void shouldReturnListOfMemberWhenUserHasAdminRole() throws Exception {
-    MemberEntity randomMember = getRandomMember();
+    final MemberEntity randomMember = getRandomMember();
     mockMvc.perform(get("/members")
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))

--- a/src/test/java/com/alkemy/ong/bigtest/members/ListMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/ListMemberIntegrationTest.java
@@ -1,0 +1,56 @@
+package com.alkemy.ong.bigtest.members;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.alkemy.ong.bigtest.util.BigTest;
+import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class ListMemberIntegrationTest extends BigTest {
+
+  @Test
+  public void shouldReturnListOfMemberWhenUserHasAdminRole() throws Exception {
+    MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(get("/members")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
+        .andExpect(jsonPath("$.page", equalTo(0)))
+        .andExpect(jsonPath("$.totalPages", equalTo(1)))
+        .andExpect(jsonPath("$.members[*].id")
+            .value(hasItem(randomMember.getId().intValue())))
+        .andExpect(jsonPath("$.members[*].name")
+            .value(hasItem(randomMember.getName())))
+        .andExpect(jsonPath("$.members[*].image")
+            .value(hasItem(randomMember.getImage())))
+        .andExpect(status().isOk());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenUserHasStandardUserRole() throws Exception {
+    mockMvc.perform(get("/members")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenTokenIsNotSent() throws Exception {
+    mockMvc.perform(get("/members")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+  }
+
+}

--- a/src/test/java/com/alkemy/ong/bigtest/members/ListMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/ListMemberIntegrationTest.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.bigtest.members;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,7 +17,8 @@ public class ListMemberIntegrationTest extends BigTest {
 
   @Test
   public void shouldReturnListOfMemberWhenUserHasAdminRole() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(get("/members")
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
@@ -28,7 +30,9 @@ public class ListMemberIntegrationTest extends BigTest {
             .value(hasItem(randomMember.getName())))
         .andExpect(jsonPath("$.members[*].image")
             .value(hasItem(randomMember.getImage())))
+        .andExpect(jsonPath("$.members", hasSize(1)))
         .andExpect(status().isOk());
+
     cleanMemberData(randomMember);
   }
 

--- a/src/test/java/com/alkemy/ong/bigtest/members/UpdateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/UpdateMemberIntegrationTest.java
@@ -21,27 +21,30 @@ import org.springframework.http.MediaType;
 
 public class UpdateMemberIntegrationTest extends BigTest {
 
-  final static String newName = "Magali Kain Senior Developer Consultant";
-  final static String newImage = "https://s3.com/maga-smiling.png";
+  private static final String NEW_NAME = "Magali Kain Senior Developer Consultant";
+  private static final String NEW_IMAGE = "https://s3.com/maga-smiling.png";
 
   @Test
   public void shouldUpdateMemberWhenUserHasStandardUserRole() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
-            .content(getContent(newName, newImage))
+            .content(getContent(NEW_NAME, NEW_IMAGE))
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.id").value(randomMember.getId()))
-        .andExpect(jsonPath("$.name", equalTo(newName)))
-        .andExpect(jsonPath("$.image", equalTo(newImage)))
+        .andExpect(jsonPath("$.name", equalTo(NEW_NAME)))
+        .andExpect(jsonPath("$.image", equalTo(NEW_IMAGE)))
         .andExpect(status().isOk());
+
     assertMemberHasBeenUpdated(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnForbiddenErrorResponseWhenUserHasAdminRole() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
@@ -49,28 +52,27 @@ public class UpdateMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.message",
             equalTo("Access denied. Please, try to login again or contact your admin.")))
         .andExpect(status().isForbidden());
+
     assertMemberHasNotBeenUpdated(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnForbiddenErrorResponseWhenTokenIsNotSent() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
-    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+    mockMvc.perform(put("/members/{id}", "1")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.statusCode", equalTo(403)))
         .andExpect(jsonPath("$.message",
             equalTo("Access denied. Please, try to login again or contact your admin.")))
         .andExpect(status().isForbidden());
-    assertMemberHasNotBeenUpdated(randomMember.getId());
-    cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnBadRequestWhenNameIsNull() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
-            .content(getContent(null, newImage))
+            .content(getContent(null, NEW_IMAGE))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -78,16 +80,18 @@ public class UpdateMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.moreInfo", hasSize(1)))
         .andExpect(jsonPath("$.moreInfo", hasItem("The name must not be null")))
         .andExpect(status().isBadRequest());
+
     assertMemberHasNotBeenUpdated(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnBadRequestWhenInvalidName() throws Exception {
-    final String invalidName = "M4gálï K@1ñ";
-    final MemberEntity randomMember = getRandomMember();
+    String invalidName = "M4gálï K@1ñ";
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
-            .content(getContent(invalidName, newImage))
+            .content(getContent(invalidName, NEW_IMAGE))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -95,15 +99,17 @@ public class UpdateMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.moreInfo", hasSize(1)))
         .andExpect(jsonPath("$.moreInfo", hasItem("The name has invalid format.")))
         .andExpect(status().isBadRequest());
+
     assertMemberHasNotBeenUpdated(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnBadRequestWhenImageIsNull() throws Exception {
-    final MemberEntity randomMember = getRandomMember();
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
-            .content(getContent(newName, null))
+            .content(getContent(NEW_NAME, null))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -111,16 +117,18 @@ public class UpdateMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.moreInfo", hasSize(1)))
         .andExpect(jsonPath("$.moreInfo", hasItem("The image must not be null")))
         .andExpect(status().isBadRequest());
+
     assertMemberHasNotBeenUpdated(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnBadRequestWhenInvalidImage() throws Exception {
-    final String invalidImage = "Magali's-dog-photo.png";
-    final MemberEntity randomMember = getRandomMember();
+    String invalidImage = "Magali's-dog-photo.png";
+    MemberEntity randomMember = getRandomMember();
+
     mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
-            .content(getContent(newName, invalidImage))
+            .content(getContent(NEW_NAME, invalidImage))
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(400)))
@@ -128,15 +136,17 @@ public class UpdateMemberIntegrationTest extends BigTest {
         .andExpect(jsonPath("$.moreInfo", hasSize(1)))
         .andExpect(jsonPath("$.moreInfo", hasItem("The image has invalid format.")))
         .andExpect(status().isBadRequest());
+
     assertMemberHasNotBeenUpdated(randomMember.getId());
     cleanMemberData(randomMember);
   }
 
   @Test
   public void shouldReturnNotFoundErrorResponseWhenUserNotExist() throws Exception {
-    final String nonExistMemberId = "1000000";
+    String nonExistMemberId = "1000000";
+
     mockMvc.perform(put("/members/{id}", nonExistMemberId)
-            .content(getContent(newName, newImage))
+            .content(getContent(NEW_NAME, NEW_IMAGE))
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
         .andExpect(jsonPath("$.statusCode", equalTo(404)))
@@ -154,20 +164,20 @@ public class UpdateMemberIntegrationTest extends BigTest {
   }
 
   private void assertMemberHasBeenUpdated(Long memberId) {
-    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     assertTrue(optionalMemberEntity.isPresent());
     optionalMemberEntity.ifPresent(memberEntity -> {
-      assertEquals(newName, memberEntity.getName());
-      assertEquals(newImage, memberEntity.getImage());
+      assertEquals(NEW_NAME, memberEntity.getName());
+      assertEquals(NEW_IMAGE, memberEntity.getImage());
     });
   }
 
   private void assertMemberHasNotBeenUpdated(Long memberId) {
-    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     assertTrue(optionalMemberEntity.isPresent());
     optionalMemberEntity.ifPresent(memberEntity -> {
-      assertNotEquals(newName, memberEntity.getName());
-      assertNotEquals(newImage, memberEntity.getImage());
+      assertNotEquals(NEW_NAME, memberEntity.getName());
+      assertNotEquals(NEW_IMAGE, memberEntity.getImage());
     });
   }
 

--- a/src/test/java/com/alkemy/ong/bigtest/members/UpdateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/UpdateMemberIntegrationTest.java
@@ -154,7 +154,7 @@ public class UpdateMemberIntegrationTest extends BigTest {
   }
 
   private void assertMemberHasBeenUpdated(Long memberId) {
-    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     assertTrue(optionalMemberEntity.isPresent());
     optionalMemberEntity.ifPresent(memberEntity -> {
       assertEquals(newName, memberEntity.getName());
@@ -163,7 +163,7 @@ public class UpdateMemberIntegrationTest extends BigTest {
   }
 
   private void assertMemberHasNotBeenUpdated(Long memberId) {
-    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    final Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
     assertTrue(optionalMemberEntity.isPresent());
     optionalMemberEntity.ifPresent(memberEntity -> {
       assertNotEquals(newName, memberEntity.getName());

--- a/src/test/java/com/alkemy/ong/bigtest/members/UpdateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/members/UpdateMemberIntegrationTest.java
@@ -1,0 +1,174 @@
+package com.alkemy.ong.bigtest.members;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.alkemy.ong.application.rest.request.CreateMemberRequest;
+import com.alkemy.ong.bigtest.util.BigTest;
+import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Optional;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class UpdateMemberIntegrationTest extends BigTest {
+
+  final static String newName = "Magali Kain Senior Developer Consultant";
+  final static String newImage = "https://s3.com/maga-smiling.png";
+
+  @Test
+  public void shouldUpdateMemberWhenUserHasStandardUserRole() throws Exception {
+    final MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+            .content(getContent(newName, newImage))
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.id").value(randomMember.getId()))
+        .andExpect(jsonPath("$.name", equalTo(newName)))
+        .andExpect(jsonPath("$.image", equalTo(newImage)))
+        .andExpect(status().isOk());
+    assertMemberHasBeenUpdated(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenUserHasAdminRole() throws Exception {
+    final MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForAdminUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+    assertMemberHasNotBeenUpdated(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnForbiddenErrorResponseWhenTokenIsNotSent() throws Exception {
+    final MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.statusCode", equalTo(403)))
+        .andExpect(jsonPath("$.message",
+            equalTo("Access denied. Please, try to login again or contact your admin.")))
+        .andExpect(status().isForbidden());
+    assertMemberHasNotBeenUpdated(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenNameIsNull() throws Exception {
+    final MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+            .content(getContent(null, newImage))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The name must not be null")))
+        .andExpect(status().isBadRequest());
+    assertMemberHasNotBeenUpdated(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenInvalidName() throws Exception {
+    final String invalidName = "M4gálï K@1ñ";
+    final MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+            .content(getContent(invalidName, newImage))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The name has invalid format.")))
+        .andExpect(status().isBadRequest());
+    assertMemberHasNotBeenUpdated(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenImageIsNull() throws Exception {
+    final MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+            .content(getContent(newName, null))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The image must not be null")))
+        .andExpect(status().isBadRequest());
+    assertMemberHasNotBeenUpdated(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnBadRequestWhenInvalidImage() throws Exception {
+    final String invalidImage = "Magali's-dog-photo.png";
+    final MemberEntity randomMember = getRandomMember();
+    mockMvc.perform(put("/members/{id}", String.valueOf(randomMember.getId()))
+            .content(getContent(newName, invalidImage))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(400)))
+        .andExpect(jsonPath("$.message", equalTo("Invalid input data.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("The image has invalid format.")))
+        .andExpect(status().isBadRequest());
+    assertMemberHasNotBeenUpdated(randomMember.getId());
+    cleanMemberData(randomMember);
+  }
+
+  @Test
+  public void shouldReturnNotFoundErrorResponseWhenUserNotExist() throws Exception {
+    final String nonExistMemberId = "1000000";
+    mockMvc.perform(put("/members/{id}", nonExistMemberId)
+            .content(getContent(newName, newImage))
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, getAuthorizationTokenForStandardUser()))
+        .andExpect(jsonPath("$.statusCode", equalTo(404)))
+        .andExpect(jsonPath("$.message", equalTo("Entity not found.")))
+        .andExpect(jsonPath("$.moreInfo", hasSize(1)))
+        .andExpect(jsonPath("$.moreInfo", hasItem("Member not found.")))
+        .andExpect(status().isNotFound());
+  }
+
+  private String getContent(String name, String image) throws JsonProcessingException {
+    return objectMapper.writeValueAsString(CreateMemberRequest.builder()
+        .name(name)
+        .image(image)
+        .build());
+  }
+
+  private void assertMemberHasBeenUpdated(Long memberId) {
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    assertTrue(optionalMemberEntity.isPresent());
+    optionalMemberEntity.ifPresent(memberEntity -> {
+      assertEquals(newName, memberEntity.getName());
+      assertEquals(newImage, memberEntity.getImage());
+    });
+  }
+
+  private void assertMemberHasNotBeenUpdated(Long memberId) {
+    Optional<MemberEntity> optionalMemberEntity = memberRepository.findById(memberId);
+    assertTrue(optionalMemberEntity.isPresent());
+    optionalMemberEntity.ifPresent(memberEntity -> {
+      assertNotEquals(newName, memberEntity.getName());
+      assertNotEquals(newImage, memberEntity.getImage());
+    });
+  }
+
+}

--- a/src/test/java/com/alkemy/ong/bigtest/util/BigTest.java
+++ b/src/test/java/com/alkemy/ong/bigtest/util/BigTest.java
@@ -8,6 +8,7 @@ import com.alkemy.ong.infrastructure.database.entity.ActivityEntity;
 import com.alkemy.ong.infrastructure.database.entity.CategoryEntity;
 import com.alkemy.ong.infrastructure.database.entity.CommentEntity;
 import com.alkemy.ong.infrastructure.database.entity.ContactEntity;
+import com.alkemy.ong.infrastructure.database.entity.MemberEntity;
 import com.alkemy.ong.infrastructure.database.entity.NewsEntity;
 import com.alkemy.ong.infrastructure.database.entity.OrganizationEntity;
 import com.alkemy.ong.infrastructure.database.entity.RoleEntity;
@@ -18,6 +19,7 @@ import com.alkemy.ong.infrastructure.database.repository.IActivityRepository;
 import com.alkemy.ong.infrastructure.database.repository.ICategoryRepository;
 import com.alkemy.ong.infrastructure.database.repository.ICommentRepository;
 import com.alkemy.ong.infrastructure.database.repository.IContactRepository;
+import com.alkemy.ong.infrastructure.database.repository.IMemberRepository;
 import com.alkemy.ong.infrastructure.database.repository.INewsRepository;
 import com.alkemy.ong.infrastructure.database.repository.IOrganizationRepository;
 import com.alkemy.ong.infrastructure.database.repository.IRoleRepository;
@@ -92,6 +94,9 @@ public abstract class BigTest {
   @Autowired
   protected ITestimonialRepository testimonialRepository;
 
+  @Autowired
+  protected IMemberRepository memberRepository;
+
   @Before
   public void setup() {
     createRoles();
@@ -150,6 +155,10 @@ public abstract class BigTest {
     testimonialRepository.deleteAllInBatch(Arrays.asList(testimonial));
   }
 
+  protected void cleanMemberData(MemberEntity... member) {
+    memberRepository.deleteAllInBatch(Arrays.asList(member));
+  }
+
   private void deleteAllEntities() {
     organizationRepository.deleteAll();
     slideRepository.deleteAll();
@@ -205,6 +214,14 @@ public abstract class BigTest {
         .name("My first Testimonial!!")
         .image("https://s3.com/testimonial.jpg")
         .content("Testimonial content.")
+        .build());
+  }
+
+  protected MemberEntity getRandomMember() {
+    return memberRepository.save(MemberEntity.builder()
+        .name("Matias Espinola")
+        .image("https://s3.com/matias.png")
+        .softDeleted(false)
         .build());
   }
 


### PR DESCRIPTION
# [OT166-91: Test endpoints /members](https://alkemy-labs.atlassian.net/browse/OT166-91)

### Criterios de aceptación

- Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc.
- Los test de integración deberán ser incluidos en la carpeta **/bigtest/members**. _Se deberá crear un archivo por cada endpoint a testear_. Se puede utilizar como base el test creado a modo de demostración.
- En este caso, test unitarios son opcionales si el desarrollador quiere agregarlos.

### HOW HAS THIS BEEN TESTED?

- [ ] Postman.
- [ ] Unit test.
- [x] Integration test.
- [ ] No testing required (only applies for tech task).

**Screenshots**:

![image](https://user-images.githubusercontent.com/88750230/163926977-fbddc57d-827e-47b3-8ea1-7170a7a8ce4c.png)

### CHECKLIST

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
