### PR TITLE
OT166-79: Endpoint to list Comments based on a news (Tuples version)

### DIFF
--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/INewsRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/INewsRepository.java
@@ -1,29 +1,17 @@
 package com.alkemy.ong.infrastructure.database.repository;
 
 import com.alkemy.ong.infrastructure.database.entity.NewsEntity;
-import java.util.List;
-import java.util.Map;
+import com.alkemy.ong.infrastructure.database.repository.custom.INewsCustomRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface INewsRepository extends JpaRepository<NewsEntity, Long> {
+public interface INewsRepository extends JpaRepository<NewsEntity, Long>, INewsCustomRepository {
 
   NewsEntity findByIdAndSoftDeletedFalse(Long id);
 
   Page<NewsEntity> findBySoftDeletedFalseOrderByIdAsc(Pageable pageable);
-
-  @Query(value = "SELECT n.name AS newsName, c.id AS id, c.body AS body, "
-      + "c.user.firstName AS firstName, c.user.lastName AS lastName, "
-      + "c.createTimestamp AS createTimestamp "
-      + "FROM NewsEntity AS n "
-      + "INNER JOIN CommentEntity AS c "
-      + "ON c.news.id = :id "
-      + "WHERE n.softDeleted = false")
-  List<Map<String, Object>> findNewsWithAssociatedCommentsBy(@Param("id") Long id);
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/custom/INewsCustomRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/custom/INewsCustomRepository.java
@@ -1,0 +1,10 @@
+package com.alkemy.ong.infrastructure.database.repository.custom;
+
+import java.util.List;
+import javax.persistence.Tuple;
+
+public interface INewsCustomRepository {
+
+  List<Tuple> findByCriteria(Long id);
+
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/custom/INewsCustomRepositoryImpl.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/custom/INewsCustomRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.alkemy.ong.infrastructure.database.repository.custom;
+
+import com.alkemy.ong.infrastructure.database.entity.CommentEntity;
+import com.alkemy.ong.infrastructure.database.entity.NewsEntity;
+import com.alkemy.ong.infrastructure.database.entity.UserEntity;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+public class INewsCustomRepositoryImpl implements INewsCustomRepository {
+
+  private final EntityManager entityManager;
+  private final CriteriaBuilder criteriaBuilder;
+
+  public INewsCustomRepositoryImpl(EntityManager entityManager) {
+    this.entityManager = entityManager;
+    this.criteriaBuilder = entityManager.getCriteriaBuilder();
+  }
+
+  @Override
+  public List<Tuple> findByCriteria(Long id) {
+    CriteriaQuery<Tuple> criteriaQuery = criteriaBuilder.createTupleQuery();
+    Root<NewsEntity> newsRoot = criteriaQuery.from(NewsEntity.class);
+    Root<CommentEntity> commentRoot = criteriaQuery.from(CommentEntity.class);
+
+    Join<CommentEntity, NewsEntity> comment = commentRoot.join("news");
+    Join<CommentEntity, UserEntity> user = commentRoot.join("user");
+    Expression<String> userFullName = getUserFullName(user);
+
+    criteriaQuery.multiselect(
+            newsRoot.get("name"),
+            commentRoot.get("id"),
+            commentRoot.get("body"),
+            userFullName,
+            commentRoot.get("createTimestamp"))
+        .where(getPredicate(newsRoot, id));
+
+    return entityManager.createQuery(criteriaQuery).getResultList();
+  }
+
+  private Expression<String> getUserFullName(Join<CommentEntity, UserEntity> joinUser) {
+    return criteriaBuilder.concat(joinUser.get("firstName"),
+        criteriaBuilder.concat(" ", joinUser.get("lastName")));
+  }
+
+  private Predicate getPredicate(Root<NewsEntity> root, Long id) {
+    List<Predicate> predicates = new ArrayList<>();
+    predicates.add(criteriaBuilder.equal(root.get("softDeleted"), false));
+    predicates.add(criteriaBuilder.equal(root.get("id"), id));
+
+    return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+  }
+}


### PR DESCRIPTION
# [OT166-79: Endpoint to list Comments based on a news](https://alkemy-labs.atlassian.net/browse/OT166-79)

### Importante

El código fue planteado hace unas semanas por @devfacu. Yo solo cree la rama y lo codeé. 

### Criterios de aceptación
**GET /news/:id/comments** - Devolverá todos los comments pertenecientes a una news

### HOW HAS THIS BEEN TESTED?

- [x] Postman.
- [ ] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

**Screenshots**:

![Screenshot_1](https://user-images.githubusercontent.com/88750230/167317050-9ac8f563-73c4-4c86-8f9c-88c80af93803.png)

![Screenshot_2](https://user-images.githubusercontent.com/88750230/167317285-2772c914-278b-4581-98db-82e57d59d781.png)

### CHECKLIST

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
